### PR TITLE
Add css live reload

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -47,5 +47,6 @@
                 :cache-analysis true
                 :main "ui.core"}}]}
   :figwheel {:http-server-root "public"
+             :css-dirs ["resources/public/css"]
              :ring-handler tools.figwheel-middleware/app
              :server-port 3449})


### PR DESCRIPTION
Figwheel supports css live reloading.
From figwheel docs:
> 
```clojure
   ;; CSS reloading (optional)
   ;; :css-dirs has no default value 
   ;; if :css-dirs is set figwheel will detect css file changes and
   ;; send them to the browser
   :css-dirs ["resources/public/css"]
```